### PR TITLE
Fix compile errors

### DIFF
--- a/src/main/groovy/com/moqui/graphql/GraphQLApi.groovy
+++ b/src/main/groovy/com/moqui/graphql/GraphQLApi.groovy
@@ -131,7 +131,7 @@ class GraphQLApi {
                 for (GraphQLError error in executionResult.getErrors()) {
                     errorMap = new LinkedHashMap<>()
                     errorMap.put('message', error.getMessage())
-                    errorMap.put('errorType', error.getErrorType())
+                    errorMap.put('errorType', error.getErrorType().toString())
                     if (error instanceof ExceptionWhileDataFetching) {
                         Throwable t = ((ExceptionWhileDataFetching) error).getException()
                         if (t instanceof DataFetchingException)

--- a/src/main/groovy/com/moqui/impl/service/fetcher/EntityBatchedDataFetcher.groovy
+++ b/src/main/groovy/com/moqui/impl/service/fetcher/EntityBatchedDataFetcher.groovy
@@ -122,7 +122,7 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
             //          - Even no pagination, how to apply limit equally to each actual find if they are combined into one.
             //
             if (operation == "one") {
-                List<Map<String, Object>> jointValueList
+                List<Map<String, Object>> jointValueList = new ArrayList<>()
                 if (!useCache) {
                     EntityFind efConcrete = ec.entity.find(entityName)
                             .useCache(useCache)
@@ -132,7 +132,6 @@ class EntityBatchedDataFetcher extends BaseEntityDataFetcher implements BatchedD
                     jointValueList = mergeWithInterfaceValue(ec, efConcrete.list().getValueMapList())
 
                 } else {
-                    jointValueList = new ArrayList<>(sourceItemCount)
                     ((List) environment.source).eachWithIndex { Object object, int index ->
                         Map sourceItem = (Map) object
                         EntityFind efConcrete = ec.entity.find(entityName).useCache(useCache)


### PR DESCRIPTION
This fixes a couple of compile-time errors I encountered when installing moqui-graphql in the latest version of moqui-framework